### PR TITLE
feat(lang): add language parameter to VariableTypeInterface

### DIFF
--- a/src/Admin/Layouts/Pages/EditLayout.php
+++ b/src/Admin/Layouts/Pages/EditLayout.php
@@ -2,8 +2,12 @@
 
 namespace SmartCms\TemplateBuilder\Admin\Layouts\Pages;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Enums\IconPosition;
+use Filament\Support\Enums\Size;
+use Filament\Support\Icons\Heroicon;
 use SmartCms\Support\Admin\Components\Actions\SaveAction;
 use SmartCms\Support\Admin\Components\Actions\SaveAndClose;
 use SmartCms\TemplateBuilder\Admin\Layouts\LayoutResource;
@@ -33,14 +37,14 @@ class EditLayout extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            \Filament\Actions\ActionGroup::make([
+            ActionGroup::make([
                 SaveAction::make($this),
                 SaveAndClose::make($this, LayoutResource::getUrl('index')),
                 DeleteAction::make(),
             ])->link()->label(__('support::admin.actions'))
-                ->icon(\Filament\Support\Icons\Heroicon::ChevronDown)
-                ->size(\Filament\Support\Enums\Size::Small)
-                ->iconPosition(\Filament\Support\Enums\IconPosition::After)
+                ->icon(Heroicon::ChevronDown)
+                ->size(Size::Small)
+                ->iconPosition(IconPosition::After)
                 ->color('primary'),
         ];
     }

--- a/src/Admin/Sections/Pages/EditSection.php
+++ b/src/Admin/Sections/Pages/EditSection.php
@@ -2,8 +2,12 @@
 
 namespace SmartCms\TemplateBuilder\Admin\Sections\Pages;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Enums\IconPosition;
+use Filament\Support\Enums\Size;
+use Filament\Support\Icons\Heroicon;
 use SmartCms\Support\Admin\Components\Actions\SaveAction;
 use SmartCms\Support\Admin\Components\Actions\SaveAndClose;
 use SmartCms\TemplateBuilder\Admin\Sections\SectionResource;
@@ -16,14 +20,14 @@ class EditSection extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            \Filament\Actions\ActionGroup::make([
+            ActionGroup::make([
                 SaveAction::make($this),
                 SaveAndClose::make($this, SectionResource::getUrl('index')),
                 DeleteAction::make(),
             ])->link()->label(__('support::admin.actions'))
-                ->icon(\Filament\Support\Icons\Heroicon::ChevronDown)
-                ->size(\Filament\Support\Enums\Size::Small)
-                ->iconPosition(\Filament\Support\Enums\IconPosition::After)
+                ->icon(Heroicon::ChevronDown)
+                ->size(Size::Small)
+                ->iconPosition(IconPosition::After)
                 ->color('primary'),
         ];
     }

--- a/src/Models/Section.php
+++ b/src/Models/Section.php
@@ -2,6 +2,7 @@
 
 namespace SmartCms\TemplateBuilder\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use SmartCms\TemplateBuilder\Support\TemplateTypeEnum;
@@ -19,7 +20,7 @@ use Spatie\Translatable\HasTranslations;
  * @property array $value The values for the section.
  * @property \DateTime $created_at The date and time when the model was created.
  * @property \DateTime $updated_at The date and time when the model was last updated.
- * @property-read \Illuminate\Database\Eloquent\Collection|\SmartCms\TemplateBuilder\Models\Template[] $templates The templates using this section.
+ * @property-read Collection|Template[] $templates The templates using this section.
  */
 class Section extends Model
 {

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $entity_id The ID of the entity this template belongs to.
  * @property \DateTime $created_at The date and time when the model was created.
  * @property \DateTime $updated_at The date and time when the model was last updated.
- * @property-read \SmartCms\TemplateBuilder\Models\Section $section The template section.
+ * @property-read Section $section The template section.
  * @property-read mixed $entity The entity this template belongs to.
  */
 class Template extends Model

--- a/src/Support/VariableTypeInterface.php
+++ b/src/Support/VariableTypeInterface.php
@@ -13,7 +13,7 @@ interface VariableTypeInterface
 
     public function getDefaultValue(): mixed;
 
-    public function getSchema(string $name): Field | Component;
+    public function getSchema(string $name, ?string $language = null): Field | Component;
 
     public function getValue(mixed $value): mixed;
 }

--- a/src/Support/VariableTypeRegistry.php
+++ b/src/Support/VariableTypeRegistry.php
@@ -56,7 +56,7 @@ class VariableTypeRegistry
         $type = $this->get($type);
         if (! $type) {
             if ($this->shouldThrowError) {
-                throw new \InvalidArgumentException("Invalid type for variable $name");
+                throw new InvalidArgumentException("Invalid type for variable $name");
             }
 
             return null;
@@ -100,7 +100,7 @@ class VariableTypeRegistry
         $type = $this->get($type);
         if (! $type) {
             if ($this->shouldThrowError) {
-                throw new \InvalidArgumentException("Invalid type for variable $name");
+                throw new InvalidArgumentException("Invalid type for variable $name");
             }
 
             return null;

--- a/src/Traits/HasLayout.php
+++ b/src/Traits/HasLayout.php
@@ -4,6 +4,7 @@ namespace SmartCms\TemplateBuilder\Traits;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use SmartCms\TemplateBuilder\Actions\TemplateParser;
 use SmartCms\TemplateBuilder\Models\Layout;
 use SmartCms\TemplateBuilder\Support\TemplateTypeEnum;
@@ -28,7 +29,7 @@ trait HasLayout
     /**
      * Get the template relationship.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
+     * @return MorphOne
      */
     public function layout()
     {

--- a/src/Traits/HasTemplate.php
+++ b/src/Traits/HasTemplate.php
@@ -2,6 +2,7 @@
 
 namespace SmartCms\TemplateBuilder\Traits;
 
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use SmartCms\TemplateBuilder\Models\Template;
 
 /**
@@ -12,7 +13,7 @@ trait HasTemplate
     /**
      * Get the template relationship.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
+     * @return MorphOne
      */
     public function template()
     {

--- a/src/VariableTypes/ArrayType.php
+++ b/src/VariableTypes/ArrayType.php
@@ -24,7 +24,7 @@ class ArrayType implements VariableTypeInterface
         return [];
     }
 
-    public function getSchema(string $name): Field | Component
+    public function getSchema(string $name, ?string $language = null): Field | Component
     {
         return Repeater::make($name)->columns(2);
     }

--- a/src/VariableTypes/BoolType.php
+++ b/src/VariableTypes/BoolType.php
@@ -24,7 +24,7 @@ class BoolType implements VariableTypeInterface
         return false;
     }
 
-    public function getSchema(string $name): Field | Component
+    public function getSchema(string $name, ?string $language = null): Field | Component
     {
         return Toggle::make($name);
     }

--- a/src/VariableTypes/HtmlType.php
+++ b/src/VariableTypes/HtmlType.php
@@ -24,7 +24,7 @@ class HtmlType implements VariableTypeInterface
         return $this->mutateString('<b>Default HTML</b>');
     }
 
-    public function getSchema(string $name): Field | Component
+    public function getSchema(string $name, ?string $language = null): Field | Component
     {
         return RichEditor::make($name)
             ->columnSpanFull()

--- a/src/VariableTypes/ImageType.php
+++ b/src/VariableTypes/ImageType.php
@@ -29,7 +29,7 @@ class ImageType implements VariableTypeInterface
         ];
     }
 
-    public function getSchema(string $name): Field | Component
+    public function getSchema(string $name, ?string $language = null): Field | Component
     {
         return ImageUpload::make($name, label: 'Image');
     }

--- a/src/VariableTypes/TextType.php
+++ b/src/VariableTypes/TextType.php
@@ -24,7 +24,7 @@ class TextType implements VariableTypeInterface
         return 'Default text';
     }
 
-    public function getSchema(string $name): Field | Component
+    public function getSchema(string $name, ?string $language = null): Field | Component
     {
         return TextInput::make($name);
     }


### PR DESCRIPTION
## Summary
- Add optional `$language` parameter to `VariableTypeInterface::getSchema()`
- Update all built-in variable types signatures

## Test plan
- [ ] Existing variable types work without passing language (backward compatible)